### PR TITLE
Changes for new devkitARM and ctrulib

### DIFF
--- a/Makefile.3ds
+++ b/Makefile.3ds
@@ -39,7 +39,7 @@ APP_AUTHOR      := mtheall
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-ARCH     := -march=armv6k -mtune=mpcore -mfloat-abi=softfp
+ARCH     := -march=armv6k -mtune=mpcore -mfloat-abi=hard
 
 CFLAGS   := -g -Wall -O3 -mword-relocations \
             -fomit-frame-pointer -ffast-math \

--- a/source/ftp.c
+++ b/source/ftp.c
@@ -167,10 +167,9 @@ static const size_t num_ftp_commands = sizeof(ftp_commands)/sizeof(ftp_commands[
 
 static inline int Errno(void)
 {
-  int err = SOC_GetErrno();
-  if(err < 0)
-    return -err;
-  return err;
+  if(errno < 0)
+    return -errno;
+  return errno;
 }
 
 /*! compare ftp command descriptors


### PR DESCRIPTION
devkitARM now requires -mfloat-abi=hard, and [SOC now uses errno](https://github.com/smealum/ctrulib/commit/e75fd8b648a232c62ce49f4846b8dd64098ca67f).