### PR TITLE
Fix Ninjhax output name and icon usage

### DIFF
--- a/Makefile.3ds
+++ b/Makefile.3ds
@@ -26,7 +26,7 @@ include $(DEVKITARM)/3ds_rules
 #     - icon.png
 #     - <libctru folder>/default_icon.png
 #---------------------------------------------------------------------------------
-TARGET   := $(notdir $(CURDIR))
+TARGET   := ftbrony
 BUILD    := build
 SOURCES  := source
 DATA     := data
@@ -35,6 +35,7 @@ INCLUDES := include
 APP_TITLE       := ftBRONY
 APP_DESCRIPTION := Like ftPONY but magical.
 APP_AUTHOR      := mtheall
+ICON            := ftbrony.png
 
 #---------------------------------------------------------------------------------
 # options for code generation


### PR DESCRIPTION
It's better to give an output name instead of using the name of the current directory, so 'ftbrony' is used as default. I also fixed the icon not being used in SMDH creation (project name is ftbrony-master when downloaded from GitHub, not ftbrony).